### PR TITLE
#118 migrations rollback

### DIFF
--- a/backend/resources/org/akvo/dash/migrations_tenant_manager/001-tenants.up.sql
+++ b/backend/resources/org/akvo/dash/migrations_tenant_manager/001-tenants.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS tenants (
     id serial,
     db_uri text,
     enabled BOOLEAN NOT NULL DEFAULT TRUE,
-    label text,
+    label text UNIQUE,
     title text
 );
 

--- a/backend/test/org/akvo/dash/fixtures.clj
+++ b/backend/test/org/akvo/dash/fixtures.clj
@@ -24,5 +24,5 @@
                                  :title "Tenant 2"})
       (migrate/migrate conn)
       (f)
-      (migrate/rollback conn [])
+      (migrate/rollback conn [:all])
       (finally (stop)))))


### PR DESCRIPTION
The migrations weren't completely rolled back in fixtures resulting in multiple records of tenants after testing more than once.

I'm fixing this by rolling back fully and I'm also adding a UNIQUE constraint to the tenants.label field to safeguard against it happening again (And other bad things that might come from not having unique labels).